### PR TITLE
feat: add paypal messages example

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -83,9 +83,7 @@
             Messages
             <ul>
               <li>
-                <a href="/client/paypalMessages/basic/src/index.html"
-                  >Basic</a
-                >
+                <a href="/client/paypalMessages/basic/src/index.html">Basic</a>
               </li>
             </ul>
           </li>

--- a/client/index.html
+++ b/client/index.html
@@ -79,6 +79,16 @@
               </li>
             </ul>
           </li>
+          <li>
+            Messages
+            <ul>
+              <li>
+                <a href="/client/paypalMessages/basic/src/index.html"
+                  >Basic</a
+                >
+              </li>
+            </ul>
+          </li>
         </ul>
       </li>
     </ul>

--- a/client/paypalMessages/basic/src/app.js
+++ b/client/paypalMessages/basic/src/app.js
@@ -1,0 +1,41 @@
+async function onPayPalCheckoutV6Loaded() {
+  try {
+    const braintreeClientToken = await getBraintreeBrowserSafeClientToken();
+    const braintreeInstance = await window.braintree.client.create({
+      authorization: braintreeClientToken,
+    });
+
+    const paypalCheckoutV6Instance =
+      await window.braintree.paypalCheckoutV6.create({
+        client: braintreeInstance,
+      });
+
+    await paypalCheckoutV6Instance.loadPayPalSDK();
+
+    await setupPayPalMessages(paypalCheckoutV6Instance);
+  } catch (error) {
+    renderAlert({ type: "danger", message: "Failed to initialize PayPal" });
+    console.error(error);
+  }
+}
+
+async function setupPayPalMessages(paypalCheckoutV6Instance) {
+  await paypalCheckoutV6Instance.createMessages({
+    currency: "USD",
+  });
+}
+
+async function getBraintreeBrowserSafeClientToken() {
+  const response = await fetch(
+    "/braintree-api/auth/browser-safe-client-token",
+    {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+  const { clientToken } = await response.json();
+
+  return clientToken;
+}

--- a/client/paypalMessages/basic/src/index.html
+++ b/client/paypalMessages/basic/src/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>PayPal Messages</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="/client/shared/styles.css" />
+    <style>
+      alert-component {
+        max-width: 50rem;
+        margin-top: 4rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>PayPal Messages</h1>
+    <p>
+      This is the recommended integration pattern for Braintree merchants using
+      the PayPal Messages.
+    </p>
+
+    <paypal-message
+      id="paypal-message"
+      auto-bootstrap
+      amount="50"
+      currency-code="USD"
+    ></paypal-message>
+
+    <script src="app.js"></script>
+
+    <script src="https://js.braintreegateway.com/web/3.141.0/js/client.min.js"></script>
+    <script
+      async
+      src="https://js.braintreegateway.com/web/3.141.0/js/paypal-checkout-v6.min.js"
+      onload="onPayPalCheckoutV6Loaded()"
+    ></script>
+  </body>
+</html>

--- a/client/paypalMessages/basic/src/index.html
+++ b/client/paypalMessages/basic/src/index.html
@@ -23,6 +23,7 @@
       id="paypal-message"
       auto-bootstrap
       amount="50"
+      buyer-country="US"
       currency-code="USD"
     ></paypal-message>
 


### PR DESCRIPTION
This PR adds a basic PayPal Messages example
<img width="1550" height="306" alt="Screenshot 2026-05-19 at 12 47 33 PM" src="https://github.com/user-attachments/assets/725f5053-8498-41d2-be01-925e0cb0e364" />
