### PR TITLE
dockerignore + npm ci tidy-ups

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@
 .github
 .claude
 server/node/dist
+client/temp

--- a/.github/workflows/fly-deploy-test.yml
+++ b/.github/workflows/fly-deploy-test.yml
@@ -2,9 +2,6 @@ name: Fly Deploy (Test)
 
 on:
   workflow_dispatch:
-  push:
-    branches-ignore:
-      - main
 
 jobs:
   deploy:

--- a/.github/workflows/fly-deploy-test.yml
+++ b/.github/workflows/fly-deploy-test.yml
@@ -1,0 +1,22 @@
+name: Fly Deploy (Test)
+
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy test app
+    runs-on: ubuntu-latest
+    environment: fly-test
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io (test)
+        run: flyctl deploy --remote-only --config fly-test.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_TEST }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,13 @@ RUN apt-get update -qq && \
 # Install server dependencies
 COPY server/node/.npmrc server/node/package.json server/node/package-lock.json* ./server/node/
 WORKDIR /app/server/node
-RUN npm install --include=dev
+RUN npm ci --include=dev
 
 # Install React client dependencies
 WORKDIR /app
 COPY client/prebuiltPages/react/package.json client/prebuiltPages/react/package-lock.json* ./client/prebuiltPages/react/
 WORKDIR /app/client/prebuiltPages/react
-RUN npm install --include=dev
+RUN npm ci --include=dev
 
 # Copy all application code
 WORKDIR /app

--- a/fly-test.toml
+++ b/fly-test.toml
@@ -1,0 +1,25 @@
+# fly.toml app configuration file for the test deployment
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'v6-web-sdk-with-braintree-sdk-sample-integration-test'
+primary_region = 'ord'
+
+[build]
+
+[env]
+  HOSTNAME = '0.0.0.0'
+  PORT = '3000'
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '1gb'
+  cpus = 1


### PR DESCRIPTION
## S
<img width="1501" height="802" alt="Screenshot 2026-06-05 at 5 08 44 PM" src="https://github.com/user-attachments/assets/4ab4bbaa-f21c-4932-9de8-c17122fdaefd" />
ummary

Closes [DTPPCPSDK-6341](https://paypal.atlassian.net/browse/DTPPCPSDK-6341).

The ticket's main Dockerfile changes (install + build the prebuilt React app) were already landed in #32. This PR cleans up what's left:

1. **Add `client/temp` to `.dockerignore`** — parity with the reference repo (`v6-web-sdk-sample-integration`), per ticket.
2. **Switch `npm install --include=dev` → `npm ci --include=dev`** in the Dockerfile build stage (server + React). `npm ci` is the recommended install command for CI/Docker builds: reproducible (strict lockfile), faster (no version resolution), fails fast on lockfile drift. Both lockfiles are already present and in sync.

### Test scaffold added in this PR
3. **`.github/workflows/fly-deploy-test.yml`** — new workflow that deploys non-main branches to a separate fly.io test app. Triggers on `workflow_dispatch` (manual) + `push` (any non-main branch). Used to verify the Dockerfile changes above.
4. **`fly-test.toml`** — companion fly.io config for the test app (`v6-web-sdk-with-braintree-sdk-sample-integration-test`).

> Note: the test workflow requires a one-time setup in repo settings: a `fly-test` GitHub Environment containing a `FLY_API_TOKEN_TEST` secret.

## Test plan
- [ ] Trigger the new workflow on this branch (auto-fires on push once the environment + secret are in place) and confirm the test app comes up successfully.
- [ ] Confirm `fly deploy` to prod still succeeds after merge to main (no functional change expected).