### PR TITLE
chore: use npm ci in Dockerfile build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,13 @@ RUN apt-get update -qq && \
 # Install server dependencies
 COPY server/node/.npmrc server/node/package.json server/node/package-lock.json* ./server/node/
 WORKDIR /app/server/node
-RUN npm install --include=dev
+RUN npm ci --include=dev
 
 # Install React client dependencies
 WORKDIR /app
 COPY client/prebuiltPages/react/package.json client/prebuiltPages/react/package-lock.json* ./client/prebuiltPages/react/
 WORKDIR /app/client/prebuiltPages/react
-RUN npm install --include=dev
+RUN npm ci --include=dev
 
 # Copy all application code
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Switch the two `npm install --include=dev` calls in the Dockerfile build stage to `npm ci --include=dev` for the server and the prebuilt React app.

`npm ci` is the recommended install command for CI/Docker contexts: it installs strictly from `package-lock.json`, is faster (no version resolution), and fails fast if `package.json` and the lockfile drift apart. Both lockfiles are already present and in sync, so this is a drop-in replacement.

## Test plan
- [ ] Confirm `fly deploy` still succeeds after merge (no functional change expected).