### PR TITLE
Add React prebuilt app to Server deployed sample integration

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -90,5 +90,23 @@
         </ul>
       </li>
     </ul>
+
+    <h2>Dynamic Examples</h2>
+    <p>
+      These client-side examples use TypeScript and frameworks like React. They
+      require a build process to generate the dist folder to be served up by the
+      main server.
+    </p>
+
+    <ul>
+      <li>
+        Prebuilt Pages (React)
+        <ul>
+          <li>
+            <a href="/client/prebuiltPages/react/dist/">React Demos</a>
+          </li>
+        </ul>
+      </li>
+    </ul>
   </body>
 </html>


### PR DESCRIPTION
Technically the `dockerfile` correctly builds and ships the prebuilt React app, but there was no link to the app in `client/index.html`. This fixes that and surfaces the React app.